### PR TITLE
Add JSON-safe serialization and support JSON-format export bundle

### DIFF
--- a/clara_app/clara_classes.py
+++ b/clara_app/clara_classes.py
@@ -27,6 +27,21 @@ import string
 import unicodedata
 import copy
 
+def _json_safe_value(value):
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_value(item) for item in value]
+    if hasattr(value, 'to_json'):
+        json_value = value.to_json()
+        if isinstance(json_value, str):
+            return json.loads(json_value)
+        else:
+            return _json_safe_value(json_value)
+    return repr(value)
+
 ##class ContentElement:
 ##    def __init__(self, element_type, content, annotations=None):
 ##        self.type = element_type
@@ -207,6 +222,15 @@ class ContentElement:
             Used by simple statistics and layout heuristics.
         """
         return 1 if self.type == "Word" else 0
+
+    def to_json(self) -> str:
+        """Serialize the content element, including JSON-safe nested content."""
+        payload = {
+            "type": self.type,
+            "content": _json_safe_value(self.content),
+            "annotations": _json_safe_value(self.annotations),
+        }
+        return json.dumps(payload, ensure_ascii=False)
 
     def __repr__(self) -> str:
         """Debug-friendly representation."""
@@ -400,6 +424,14 @@ class Segment:
         # In phonetic mode, a Segment corresponds to a word if its plain text
         # has non-punctuation content.
         return 0 if string_is_only_punctuation_spaces_and_separators(self.to_text()) else 1
+
+    def to_json(self) -> str:
+        """Serialize the segment, including all content elements and annotations."""
+        payload = {
+            "content_elements": [json.loads(element.to_json()) for element in self.content_elements],
+            "annotations": _json_safe_value(self.annotations),
+        }
+        return json.dumps(payload, ensure_ascii=False)
 
     def __repr__(self) -> str:
         return f"Segment(content_elements={self.content_elements!r}, annotations={self.annotations!r})"
@@ -627,24 +659,9 @@ class Page:
         }
         """
         payload = {
-            "segments": [],
-            "annotations": self.annotations,
+            "segments": [json.loads(seg.to_json()) for seg in self.segments],
+            "annotations": _json_safe_value(self.annotations),
         }
-
-        for seg in self.segments:
-            seg_obj = {
-                "content_elements": [],
-                "annotations": seg.annotations,
-            }
-            for el in seg.content_elements:
-                seg_obj["content_elements"].append(
-                    {
-                        "type": el.type,
-                        "content": el.content,
-                        "annotations": el.annotations,
-                    }
-                )
-            payload["segments"].append(seg_obj)
 
         return json.dumps(payload, ensure_ascii=False)
 
@@ -909,7 +926,7 @@ class Text:
             "l2_language": self.l2_language,
             "l1_language": self.l1_language,
             "pages": pages_payload,
-            "annotations": self.annotations,  # new but backward-compatible
+            "annotations": _json_safe_value(self.annotations),  # new but backward-compatible
             "voice": self.voice,              # optional
         }
         return json.dumps(payload, ensure_ascii=False)

--- a/clara_app/clara_export_import.py
+++ b/clara_app/clara_export_import.py
@@ -6,10 +6,11 @@ from .clara_utils import absolute_local_file_name, absolute_file_name
 from .clara_utils import pathname_parts, file_exists, local_file_exists, basename, copy_local_file, copy_to_local_file, remove_local_file
 from .clara_utils import make_local_directory, copy_directory_to_local_directory, local_directory_exists, remove_local_directory
 from .clara_utils import get_immediate_subdirectories_in_local_directory, get_files_in_local_directory, rename_file
-from .clara_utils import make_tmp_file, write_json_to_local_file, read_json_local_file, make_zipfile, unzip_file, post_task_update
+from .clara_utils import make_tmp_file, write_json_to_local_file, read_json_local_file, write_local_txt_file, make_zipfile, unzip_file, post_task_update
 from .clara_utils import export_zipfile_pathname_for_clara_project_internal
 from .utils import audio_info_for_project
 from .clara_audio_annotator import AudioAnnotator
+from .models import Acknowledgements
 ##from .clara_audio_repository import AudioRepository
 ##from .clara_audio_repository_orm import AudioRepositoryORM
 ##from .clara_image_repository import ImageRepository
@@ -20,7 +21,7 @@ import os
 import tempfile
 import traceback
 
-def make_export_zipfile_internal(project):
+def make_export_zipfile_internal(project, export_format='normal', callback=None):
     clara_project_internal = CLARAProjectInternal(project.internal_id, project.l2, project.l1)
 
     audio_info = audio_info_for_project(project)
@@ -57,7 +58,11 @@ def make_export_zipfile_internal(project):
     result = make_export_zipfile_from_data_and_metadata(global_metadata, project_directory,
                                                         audio_metadata, audio_metadata_phonetic,
                                                         image_metadata, image_description_metadata,
-                                                        zipfile)
+                                                        zipfile,
+                                                        clara_project_internal=clara_project_internal,
+                                                        project=project,
+                                                        export_format=export_format,
+                                                        callback=callback)
     if result:
         return zipfile
     else:
@@ -70,17 +75,25 @@ def make_export_zipfile_internal(project):
 def make_export_zipfile_from_data_and_metadata(global_metadata, project_directory,
                                                audio_metadata, audio_metadata_phonetic,
                                                image_metadata, image_description_metadata,
-                                               zipfile):
+                                               zipfile,
+                                               clara_project_internal=None, project=None,
+                                               export_format='normal', callback=None):
+    tmp_dir = None
+    tmp_zipfile = None
     try:
         tmp_dir = tempfile.mkdtemp()
         tmp_zipfile = make_tmp_file('project_zip', 'zip')
 
-        write_global_metadata_to_tmp_dir(global_metadata, tmp_dir)
-        copy_project_directory_to_tmp_dir(project_directory, tmp_dir)
-        copy_audio_data_to_tmp_dir(audio_metadata, tmp_dir, phonetic=False)
-        copy_audio_data_to_tmp_dir(audio_metadata_phonetic, tmp_dir, phonetic=True)
-        copy_image_data_to_tmp_dir(image_metadata, tmp_dir)
-        copy_image_description_data_to_tmp_dir(image_description_metadata, tmp_dir)
+        write_global_metadata_to_tmp_dir(global_metadata, tmp_dir, callback=callback)
+        if export_format == 'json':
+            write_annotated_text_json_to_tmp_dir(clara_project_internal, project, global_metadata,
+                                                 tmp_dir, callback=callback)
+        else:
+            copy_project_directory_to_tmp_dir(project_directory, tmp_dir, callback=callback)
+        copy_audio_data_to_tmp_dir(audio_metadata, tmp_dir, phonetic=False, callback=callback)
+        copy_audio_data_to_tmp_dir(audio_metadata_phonetic, tmp_dir, phonetic=True, callback=callback)
+        copy_image_data_to_tmp_dir(image_metadata, tmp_dir, callback=callback)
+        copy_image_description_data_to_tmp_dir(image_description_metadata, tmp_dir, callback=callback)
         
         make_zipfile(tmp_dir, tmp_zipfile)
         copy_local_file(tmp_zipfile, zipfile)
@@ -89,9 +102,9 @@ def make_export_zipfile_from_data_and_metadata(global_metadata, project_director
         raise e
     finally:
         # Remove the tmp dir and tmp zipfile once we've used them
-        if local_directory_exists(tmp_dir):
+        if tmp_dir and local_directory_exists(tmp_dir):
             remove_local_directory(tmp_dir)
-        if local_file_exists(tmp_zipfile):
+        if tmp_zipfile and local_file_exists(tmp_zipfile):
             remove_local_file(tmp_zipfile)
 
 def write_global_metadata_to_tmp_dir(global_metadata, tmp_dir, callback=None):
@@ -105,6 +118,32 @@ def copy_project_directory_to_tmp_dir(project_directory, tmp_dir, callback=None)
     post_task_update(callback, f'--- Copying project directory')
     copy_directory_to_local_directory(project_directory, tmp_project_dir)
     post_task_update(callback, f'--- Project directory copied')
+
+def write_annotated_text_json_to_tmp_dir(clara_project_internal, project, global_metadata, tmp_dir, callback=None):
+    if not clara_project_internal or not project:
+        raise InternalCLARAError(message='Internal project and Django project are required for JSON-format export')
+
+    annotated_text_file = os.path.join(tmp_dir, 'annotated_text.json')
+    title = clara_project_internal.load_text_version_or_null('title')
+    acknowledgements_info = Acknowledgements.objects.filter(project=project).first()
+
+    post_task_update(callback, f'--- Creating annotated text JSON')
+    text_object = clara_project_internal.get_internalised_and_annotated_text(
+        title=title,
+        uses_picture_glossing=project.uses_picture_glossing,
+        picture_gloss_style=project.picture_gloss_style,
+        human_voice_id=global_metadata['human_voice_id'],
+        audio_type_for_words=global_metadata['audio_type_for_words'],
+        audio_type_for_segments=global_metadata['audio_type_for_segments'],
+        acknowledgements_info=acknowledgements_info,
+        phonetic=False,
+        callback=callback,
+    )
+    if not text_object:
+        raise InternalCLARAError(message='Unable to create internalised and annotated text for JSON-format export')
+
+    write_local_txt_file(text_object.to_json(), annotated_text_file)
+    post_task_update(callback, f'--- Written annotated text JSON to annotated_text.json')
 
 ## Format looks like this:
 ##

--- a/clara_app/export_zipfile_views.py
+++ b/clara_app/export_zipfile_views.py
@@ -144,19 +144,23 @@ def make_export_zipfile(request, project_id):
     if request.method == 'POST':
         form = MakeExportZipForm(request.POST)
         if form.is_valid():
+            export_format = form.cleaned_data['export_format']
             task_type = f'make_export_zipfile'
             callback, report_id = make_asynch_callback_and_report_id(request, task_type)
 
             # Enqueue the task
             try:
-                task_id = async_task(make_export_zipfile_with_messages, project, callback)
+                task_id = async_task(make_export_zipfile_with_messages, project, callback, export_format=export_format)
 
                 # Redirect to the monitor view, passing the task ID and report ID as parameters
                 return redirect('make_export_zipfile_monitor', project_id, report_id)
             except Exception as e:
                 messages.error(request, f"An internal error occurred in export zipfile creation. Error details: {str(e)}\n{traceback.format_exc()}")
                 form = MakeExportZipForm()
-                return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project})
+                clara_version = get_user_config(request.user)['clara_version']
+                return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project, 'clara_version': clara_version})
+        clara_version = get_user_config(request.user)['clara_version']
+        return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project, 'clara_version': clara_version})
     else:
         form = MakeExportZipForm()
 
@@ -164,9 +168,9 @@ def make_export_zipfile(request, project_id):
         
         return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project, 'clara_version': clara_version})
 
-def make_export_zipfile_with_messages(project, callback):
+def make_export_zipfile_with_messages(project, callback, export_format='normal'):
     try:
-        zipfile = make_export_zipfile_internal(project)
+        zipfile = make_export_zipfile_internal(project, export_format=export_format, callback=callback)
         post_task_update(callback, f'--- Zipfile created and copied to {zipfile}')
         post_task_update(callback, 'finished')
         return zipfile

--- a/clara_app/forms.py
+++ b/clara_app/forms.py
@@ -705,7 +705,17 @@ class CreateLemmaAndGlossTaggedTextForm(CreateAnnotatedTextForm):
         ]
 
 class MakeExportZipForm(forms.Form):
-    pass
+    EXPORT_FORMAT_CHOICES = [
+        ('normal', 'Standard C-LARA project bundle'),
+        ('json', 'C-LARA-2 bundle with annotated_text.json'),
+    ]
+
+    export_format = forms.ChoiceField(
+        choices=EXPORT_FORMAT_CHOICES,
+        initial='normal',
+        widget=forms.RadioSelect,
+        label='Export format',
+    )
 
 class RenderTextForm(forms.Form):
     pass

--- a/clara_app/templates/clara_app/make_export_zipfile.html
+++ b/clara_app/templates/clara_app/make_export_zipfile.html
@@ -7,6 +7,7 @@
   <h2>Make Export Zipfile ("{{ project.title }}")</h2>
   <form method="post" id="make_export-zipfile-form">
     {% csrf_token %}
+    {{ form.as_p }}
     <button type="submit" id="submit-button">Make zipfile</button>
   </form>
   </div>


### PR DESCRIPTION
### Motivation
- Ensure object serialization is robust to complex nested/ non-JSON-native values when producing annotated JSON output. 
- Support a new JSON-format export bundle that contains an `annotated_text.json` representation of the internal annotated text. 
- Provide a UI option to choose between the existing project bundle and the new JSON-format bundle when creating exports.

### Description
- Add a helper `_json_safe_value` and `to_json` serializers on `ContentElement` and `Segment`, and use `_json_safe_value` for `Page` and `Text` exports to produce JSON-safe payloads. 
- Extend export pipeline to accept `export_format` (`normal` or `json`) through `make_export_zipfile_internal`, `make_export_zipfile_from_data_and_metadata`, and the async task path, and to conditionally write either the legacy `project_dir` or a single `annotated_text.json`. 
- Implement `write_annotated_text_json_to_tmp_dir` which builds the annotated text via `CLARAProjectInternal.get_internalised_and_annotated_text`, includes `Acknowledgements`, writes `annotated_text.json`, and emits progress via `post_task_update`. 
- Add form UI and template changes: `MakeExportZipForm` now exposes an `export_format` radio choice and the export page renders the form fields.

### Testing
- Ran the project's automated test suite with `pytest` and observed no failures. 
- Executed automated export format checks that invoke `make_export_zipfile_internal` for both `normal` and `json` formats and verified the zipfile creation succeeded. 
- Ran JSON serialization checks on `ContentElement`/`Segment`/`Page`/`Text` `to_json` to confirm output is valid JSON and compatible with legacy readers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0c5feb308326a3fca401925b4715)