### PR TITLE
Add JSON-format project export with annotated_text.json, batch conversion command, and JSON-safe serializers

### DIFF
--- a/clara_app/clara_classes.py
+++ b/clara_app/clara_classes.py
@@ -27,6 +27,21 @@ import string
 import unicodedata
 import copy
 
+def _json_safe_value(value):
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_value(item) for item in value]
+    if hasattr(value, 'to_json'):
+        json_value = value.to_json()
+        if isinstance(json_value, str):
+            return json.loads(json_value)
+        else:
+            return _json_safe_value(json_value)
+    return repr(value)
+
 ##class ContentElement:
 ##    def __init__(self, element_type, content, annotations=None):
 ##        self.type = element_type
@@ -207,6 +222,15 @@ class ContentElement:
             Used by simple statistics and layout heuristics.
         """
         return 1 if self.type == "Word" else 0
+
+    def to_json(self) -> str:
+        """Serialize the content element, including JSON-safe nested content."""
+        payload = {
+            "type": self.type,
+            "content": _json_safe_value(self.content),
+            "annotations": _json_safe_value(self.annotations),
+        }
+        return json.dumps(payload, ensure_ascii=False)
 
     def __repr__(self) -> str:
         """Debug-friendly representation."""
@@ -400,6 +424,14 @@ class Segment:
         # In phonetic mode, a Segment corresponds to a word if its plain text
         # has non-punctuation content.
         return 0 if string_is_only_punctuation_spaces_and_separators(self.to_text()) else 1
+
+    def to_json(self) -> str:
+        """Serialize the segment, including all content elements and annotations."""
+        payload = {
+            "content_elements": [json.loads(element.to_json()) for element in self.content_elements],
+            "annotations": _json_safe_value(self.annotations),
+        }
+        return json.dumps(payload, ensure_ascii=False)
 
     def __repr__(self) -> str:
         return f"Segment(content_elements={self.content_elements!r}, annotations={self.annotations!r})"
@@ -627,24 +659,9 @@ class Page:
         }
         """
         payload = {
-            "segments": [],
-            "annotations": self.annotations,
+            "segments": [json.loads(seg.to_json()) for seg in self.segments],
+            "annotations": _json_safe_value(self.annotations),
         }
-
-        for seg in self.segments:
-            seg_obj = {
-                "content_elements": [],
-                "annotations": seg.annotations,
-            }
-            for el in seg.content_elements:
-                seg_obj["content_elements"].append(
-                    {
-                        "type": el.type,
-                        "content": el.content,
-                        "annotations": el.annotations,
-                    }
-                )
-            payload["segments"].append(seg_obj)
 
         return json.dumps(payload, ensure_ascii=False)
 
@@ -909,7 +926,7 @@ class Text:
             "l2_language": self.l2_language,
             "l1_language": self.l1_language,
             "pages": pages_payload,
-            "annotations": self.annotations,  # new but backward-compatible
+            "annotations": _json_safe_value(self.annotations),  # new but backward-compatible
             "voice": self.voice,              # optional
         }
         return json.dumps(payload, ensure_ascii=False)

--- a/clara_app/clara_export_import.py
+++ b/clara_app/clara_export_import.py
@@ -6,10 +6,11 @@ from .clara_utils import absolute_local_file_name, absolute_file_name
 from .clara_utils import pathname_parts, file_exists, local_file_exists, basename, copy_local_file, copy_to_local_file, remove_local_file
 from .clara_utils import make_local_directory, copy_directory_to_local_directory, local_directory_exists, remove_local_directory
 from .clara_utils import get_immediate_subdirectories_in_local_directory, get_files_in_local_directory, rename_file
-from .clara_utils import make_tmp_file, write_json_to_local_file, read_json_local_file, make_zipfile, unzip_file, post_task_update
+from .clara_utils import make_tmp_file, write_json_to_local_file, read_json_local_file, write_local_txt_file, make_zipfile, unzip_file, post_task_update
 from .clara_utils import export_zipfile_pathname_for_clara_project_internal
 from .utils import audio_info_for_project
 from .clara_audio_annotator import AudioAnnotator
+from .models import Acknowledgements
 ##from .clara_audio_repository import AudioRepository
 ##from .clara_audio_repository_orm import AudioRepositoryORM
 ##from .clara_image_repository import ImageRepository
@@ -19,8 +20,9 @@ from pathlib import Path
 import os
 import tempfile
 import traceback
+import json
 
-def make_export_zipfile_internal(project):
+def make_export_zipfile_internal(project, export_format='normal', callback=None):
     clara_project_internal = CLARAProjectInternal(project.internal_id, project.l2, project.l1)
 
     audio_info = audio_info_for_project(project)
@@ -57,7 +59,11 @@ def make_export_zipfile_internal(project):
     result = make_export_zipfile_from_data_and_metadata(global_metadata, project_directory,
                                                         audio_metadata, audio_metadata_phonetic,
                                                         image_metadata, image_description_metadata,
-                                                        zipfile)
+                                                        zipfile,
+                                                        clara_project_internal=clara_project_internal,
+                                                        project=project,
+                                                        export_format=export_format,
+                                                        callback=callback)
     if result:
         return zipfile
     else:
@@ -70,17 +76,25 @@ def make_export_zipfile_internal(project):
 def make_export_zipfile_from_data_and_metadata(global_metadata, project_directory,
                                                audio_metadata, audio_metadata_phonetic,
                                                image_metadata, image_description_metadata,
-                                               zipfile):
+                                               zipfile,
+                                               clara_project_internal=None, project=None,
+                                               export_format='normal', callback=None):
+    tmp_dir = None
+    tmp_zipfile = None
     try:
         tmp_dir = tempfile.mkdtemp()
         tmp_zipfile = make_tmp_file('project_zip', 'zip')
 
-        write_global_metadata_to_tmp_dir(global_metadata, tmp_dir)
-        copy_project_directory_to_tmp_dir(project_directory, tmp_dir)
-        copy_audio_data_to_tmp_dir(audio_metadata, tmp_dir, phonetic=False)
-        copy_audio_data_to_tmp_dir(audio_metadata_phonetic, tmp_dir, phonetic=True)
-        copy_image_data_to_tmp_dir(image_metadata, tmp_dir)
-        copy_image_description_data_to_tmp_dir(image_description_metadata, tmp_dir)
+        write_global_metadata_to_tmp_dir(global_metadata, tmp_dir, callback=callback)
+        if export_format == 'json':
+            write_annotated_text_json_to_tmp_dir(clara_project_internal, project, global_metadata,
+                                                 tmp_dir, callback=callback)
+        else:
+            copy_project_directory_to_tmp_dir(project_directory, tmp_dir, callback=callback)
+        copy_audio_data_to_tmp_dir(audio_metadata, tmp_dir, phonetic=False, callback=callback)
+        copy_audio_data_to_tmp_dir(audio_metadata_phonetic, tmp_dir, phonetic=True, callback=callback)
+        copy_image_data_to_tmp_dir(image_metadata, tmp_dir, callback=callback)
+        copy_image_description_data_to_tmp_dir(image_description_metadata, tmp_dir, callback=callback)
         
         make_zipfile(tmp_dir, tmp_zipfile)
         copy_local_file(tmp_zipfile, zipfile)
@@ -89,9 +103,9 @@ def make_export_zipfile_from_data_and_metadata(global_metadata, project_director
         raise e
     finally:
         # Remove the tmp dir and tmp zipfile once we've used them
-        if local_directory_exists(tmp_dir):
+        if tmp_dir and local_directory_exists(tmp_dir):
             remove_local_directory(tmp_dir)
-        if local_file_exists(tmp_zipfile):
+        if tmp_zipfile and local_file_exists(tmp_zipfile):
             remove_local_file(tmp_zipfile)
 
 def write_global_metadata_to_tmp_dir(global_metadata, tmp_dir, callback=None):
@@ -105,6 +119,52 @@ def copy_project_directory_to_tmp_dir(project_directory, tmp_dir, callback=None)
     post_task_update(callback, f'--- Copying project directory')
     copy_directory_to_local_directory(project_directory, tmp_project_dir)
     post_task_update(callback, f'--- Project directory copied')
+
+def write_annotated_text_json_to_tmp_dir(clara_project_internal, project, global_metadata, tmp_dir, callback=None):
+    if not clara_project_internal or not project:
+        raise InternalCLARAError(message='Internal project and Django project are required for JSON-format export')
+
+    annotated_text_file = os.path.join(tmp_dir, 'annotated_text.json')
+    title = clara_project_internal.load_text_version_or_null('title')
+    acknowledgements_info = Acknowledgements.objects.filter(project=project).first()
+
+    post_task_update(callback, f'--- Creating annotated text JSON')
+    text_object = clara_project_internal.get_internalised_and_annotated_text(
+        title=title,
+        uses_picture_glossing=project.uses_picture_glossing,
+        picture_gloss_style=project.picture_gloss_style,
+        human_voice_id=global_metadata['human_voice_id'],
+        audio_type_for_words=global_metadata['audio_type_for_words'],
+        audio_type_for_segments=global_metadata['audio_type_for_segments'],
+        acknowledgements_info=acknowledgements_info,
+        phonetic=False,
+        callback=callback,
+    )
+    if not text_object:
+        raise InternalCLARAError(message='Unable to create internalised and annotated text for JSON-format export')
+
+    annotated_text_json = json.loads(text_object.to_json())
+    normalise_audio_file_paths_in_annotated_text_json(annotated_text_json)
+    write_local_txt_file(json.dumps(annotated_text_json, ensure_ascii=False), annotated_text_file)
+    post_task_update(callback, f'--- Written annotated text JSON to annotated_text.json')
+
+def normalise_audio_file_paths_in_annotated_text_json(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == 'file_path' and is_audio_file_path(item):
+                value[key] = audio_zipfile_path_for_audio_file(item)
+            else:
+                normalise_audio_file_paths_in_annotated_text_json(item)
+    elif isinstance(value, list):
+        for item in value:
+            normalise_audio_file_paths_in_annotated_text_json(item)
+
+def is_audio_file_path(value):
+    return isinstance(value, str) and value.lower().endswith(('.mp3', '.wav', '.m4a'))
+
+def audio_zipfile_path_for_audio_file(pathname):
+    normalised_pathname = pathname.replace('\\', '/')
+    return f"audio/{normalised_pathname.split('/')[-1]}"
 
 ## Format looks like this:
 ##

--- a/clara_app/export_zipfile_views.py
+++ b/clara_app/export_zipfile_views.py
@@ -144,19 +144,23 @@ def make_export_zipfile(request, project_id):
     if request.method == 'POST':
         form = MakeExportZipForm(request.POST)
         if form.is_valid():
+            export_format = form.cleaned_data['export_format']
             task_type = f'make_export_zipfile'
             callback, report_id = make_asynch_callback_and_report_id(request, task_type)
 
             # Enqueue the task
             try:
-                task_id = async_task(make_export_zipfile_with_messages, project, callback)
+                task_id = async_task(make_export_zipfile_with_messages, project, callback, export_format=export_format)
 
                 # Redirect to the monitor view, passing the task ID and report ID as parameters
                 return redirect('make_export_zipfile_monitor', project_id, report_id)
             except Exception as e:
                 messages.error(request, f"An internal error occurred in export zipfile creation. Error details: {str(e)}\n{traceback.format_exc()}")
                 form = MakeExportZipForm()
-                return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project})
+                clara_version = get_user_config(request.user)['clara_version']
+                return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project, 'clara_version': clara_version})
+        clara_version = get_user_config(request.user)['clara_version']
+        return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project, 'clara_version': clara_version})
     else:
         form = MakeExportZipForm()
 
@@ -164,9 +168,9 @@ def make_export_zipfile(request, project_id):
         
         return render(request, 'clara_app/make_export_zipfile.html', {'form': form, 'project': project, 'clara_version': clara_version})
 
-def make_export_zipfile_with_messages(project, callback):
+def make_export_zipfile_with_messages(project, callback, export_format='normal'):
     try:
-        zipfile = make_export_zipfile_internal(project)
+        zipfile = make_export_zipfile_internal(project, export_format=export_format, callback=callback)
         post_task_update(callback, f'--- Zipfile created and copied to {zipfile}')
         post_task_update(callback, 'finished')
         return zipfile

--- a/clara_app/forms.py
+++ b/clara_app/forms.py
@@ -705,7 +705,17 @@ class CreateLemmaAndGlossTaggedTextForm(CreateAnnotatedTextForm):
         ]
 
 class MakeExportZipForm(forms.Form):
-    pass
+    EXPORT_FORMAT_CHOICES = [
+        ('normal', 'Standard C-LARA project bundle'),
+        ('json', 'C-LARA-2 bundle with annotated_text.json'),
+    ]
+
+    export_format = forms.ChoiceField(
+        choices=EXPORT_FORMAT_CHOICES,
+        initial='normal',
+        widget=forms.RadioSelect,
+        label='Export format',
+    )
 
 class RenderTextForm(forms.Form):
     pass

--- a/clara_app/management/commands/convert_exported_project_bundles_to_json.py
+++ b/clara_app/management/commands/convert_exported_project_bundles_to_json.py
@@ -1,0 +1,231 @@
+import json
+import shutil
+import traceback
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from clara_app.clara_export_import import make_export_zipfile_internal
+from clara_app.create_project_views import create_CLARAProjectInternal_from_zipfile
+from clara_app.models import CLARAProject, HumanAudioInfo, PhoneticHumanAudioInfo
+from clara_app.utils import create_internal_project_id
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = (
+        "Convert a folder of legacy C-LARA project export bundles into a matching "
+        "folder of JSON-format export bundles."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "source_root",
+            help="Folder containing one subfolder per project. Each project subfolder must contain one .zip and one .json metadata file.",
+        )
+        parser.add_argument(
+            "dest_root",
+            help="Destination folder to create. It will contain matching project subfolders with JSON-format zips and copied metadata.",
+        )
+        parser.add_argument(
+            "--username",
+            default=None,
+            help="Django username to own the temporary imported projects. Defaults to the first superuser, then staff user, then any user.",
+        )
+        parser.add_argument(
+            "--existing",
+            choices=["skip", "overwrite", "error"],
+            default="skip",
+            help="What to do when an output project subfolder already exists (default: skip).",
+        )
+        parser.add_argument(
+            "--keep-imported-projects",
+            action="store_true",
+            help="Keep temporary CLARAProject database rows after conversion. By default they are deleted after each project is exported.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report which project folders would be converted without importing or writing bundles.",
+        )
+
+    def handle(self, *args, **options):
+        source_root = Path(options["source_root"]).expanduser().resolve()
+        dest_root = Path(options["dest_root"]).expanduser().resolve()
+
+        if not source_root.is_dir():
+            raise CommandError(f"Source root is not a directory: {source_root}")
+        if source_root == dest_root:
+            raise CommandError("Source and destination roots must be different directories")
+
+        owner = self._owner_user(options["username"])
+        existing = options["existing"]
+        dry_run = options["dry_run"]
+        keep_imported_projects = options["keep_imported_projects"]
+
+        project_dirs = [path for path in sorted(source_root.iterdir()) if path.is_dir()]
+        if not project_dirs:
+            raise CommandError(f"No project subdirectories found under {source_root}")
+
+        if not dry_run:
+            dest_root.mkdir(parents=True, exist_ok=True)
+
+        successes = []
+        failures = []
+        skipped = []
+
+        self.stdout.write(self.style.NOTICE(f"Source root: {source_root}"))
+        self.stdout.write(self.style.NOTICE(f"Destination root: {dest_root}"))
+        self.stdout.write(self.style.NOTICE(f"Project folders found: {len(project_dirs)}"))
+        self.stdout.write(self.style.NOTICE(f"Temporary project owner: {owner.username}"))
+
+        for source_project_dir in project_dirs:
+            try:
+                zip_path, metadata_path = self._input_files(source_project_dir)
+                dest_project_dir = dest_root / source_project_dir.name
+                dest_zip_path = dest_project_dir / zip_path.name
+                dest_metadata_path = dest_project_dir / metadata_path.name
+
+                if dest_project_dir.exists():
+                    if existing == "skip":
+                        self.stdout.write(f"- skip existing output: {dest_project_dir}")
+                        skipped.append(source_project_dir.name)
+                        continue
+                    if existing == "error":
+                        raise CommandError(f"Output project directory already exists: {dest_project_dir}")
+                    if not dry_run:
+                        shutil.rmtree(dest_project_dir)
+
+                self.stdout.write(f"- convert {source_project_dir.name}: {zip_path.name} -> {dest_zip_path}")
+                if dry_run:
+                    successes.append(source_project_dir.name)
+                    continue
+
+                dest_project_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(metadata_path, dest_metadata_path)
+                self._convert_one_project(zip_path, metadata_path, dest_zip_path, owner, keep_imported_projects)
+                successes.append(source_project_dir.name)
+
+            except Exception as e:
+                message = f"{type(e).__name__}: {e}"
+                self.stderr.write(self.style.ERROR(f"  ERROR {source_project_dir.name}: {message}"))
+                failures.append({
+                    "project_dir": source_project_dir.name,
+                    "error": message,
+                    "traceback": traceback.format_exc(),
+                })
+
+        if not dry_run:
+            (dest_root / "conversion_index.json").write_text(
+                json.dumps({
+                    "source_root": str(source_root),
+                    "dest_root": str(dest_root),
+                    "converted": successes,
+                    "skipped": skipped,
+                    "failures": failures,
+                }, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Done. converted={len(successes)} skipped={len(skipped)} failures={len(failures)}"
+        ))
+        if failures:
+            raise CommandError(f"{len(failures)} project(s) failed; see conversion_index.json in {dest_root}")
+
+    def _owner_user(self, username):
+        if username:
+            try:
+                return User.objects.get(username=username)
+            except User.DoesNotExist as e:
+                raise CommandError(f"No Django user found with username '{username}'") from e
+
+        user = User.objects.filter(is_superuser=True).order_by("id").first()
+        if not user:
+            user = User.objects.filter(is_staff=True).order_by("id").first()
+        if not user:
+            user = User.objects.order_by("id").first()
+        if not user:
+            raise CommandError("No Django users exist. Create a user first or pass --username.")
+        return user
+
+    def _input_files(self, source_project_dir):
+        zip_files = sorted(source_project_dir.glob("*.zip"))
+        json_files = sorted(source_project_dir.glob("*.json"))
+
+        if len(zip_files) != 1:
+            raise CommandError(f"Expected exactly one .zip file in {source_project_dir}, found {len(zip_files)}")
+        if len(json_files) != 1:
+            raise CommandError(f"Expected exactly one .json metadata file in {source_project_dir}, found {len(json_files)}")
+        return zip_files[0], json_files[0]
+
+    def _convert_one_project(self, zip_path, metadata_path, dest_zip_path, owner, keep_imported_project):
+        metadata = self._read_metadata(metadata_path)
+        title = (metadata.get("title") or zip_path.stem or "Imported C-LARA project")[:200]
+        l1 = metadata.get("l1") or "english"
+        l2 = metadata.get("l2") or "english"
+
+        clara_project = CLARAProject.objects.create(
+            title=title,
+            internal_id="",
+            user=owner,
+            l1=l1,
+            l2=l2,
+        )
+        clara_project.internal_id = create_internal_project_id(title, clara_project.id)
+        clara_project.save()
+
+        try:
+            clara_project_internal, global_metadata = create_CLARAProjectInternal_from_zipfile(
+                str(zip_path), clara_project.internal_id, callback=None
+            )
+            if clara_project_internal is None:
+                raise CommandError(f"Unable to import legacy bundle {zip_path}")
+
+            self._update_project_from_import(clara_project, clara_project_internal, global_metadata)
+            exported_zip_path = Path(make_export_zipfile_internal(clara_project, export_format="json", callback=None))
+            if not exported_zip_path.exists():
+                raise FileNotFoundError(f"JSON-format export zip was not created: {exported_zip_path}")
+            shutil.copy2(exported_zip_path, dest_zip_path)
+        finally:
+            if not keep_imported_project:
+                clara_project.delete()
+
+    def _read_metadata(self, metadata_path):
+        try:
+            return json.loads(metadata_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def _update_project_from_import(self, clara_project, clara_project_internal, global_metadata):
+        clara_project.l1 = clara_project_internal.l1_language
+        clara_project.l2 = clara_project_internal.l2_language
+
+        if global_metadata and isinstance(global_metadata, dict):
+            for field_name in [
+                "simple_clara_type",
+                "uses_coherent_image_set",
+                "uses_coherent_image_set_v2",
+                "use_translation_for_images",
+                "uses_picture_glossing",
+                "picture_gloss_style",
+            ]:
+                if field_name in global_metadata:
+                    setattr(clara_project, field_name, global_metadata[field_name])
+
+            if global_metadata.get("human_voice_id"):
+                human_audio_info, _ = HumanAudioInfo.objects.get_or_create(project=clara_project)
+                human_audio_info.voice_talent_id = global_metadata["human_voice_id"]
+                human_audio_info.use_for_words = global_metadata.get("audio_type_for_words") == "human"
+                human_audio_info.use_for_segments = global_metadata.get("audio_type_for_segments") == "human"
+                human_audio_info.save()
+
+            if global_metadata.get("human_voice_id_phonetic"):
+                phonetic_human_audio_info, _ = PhoneticHumanAudioInfo.objects.get_or_create(project=clara_project)
+                phonetic_human_audio_info.voice_talent_id = global_metadata["human_voice_id_phonetic"]
+                phonetic_human_audio_info.use_for_words = True
+                phonetic_human_audio_info.save()
+
+        clara_project.save()

--- a/clara_app/templates/clara_app/make_export_zipfile.html
+++ b/clara_app/templates/clara_app/make_export_zipfile.html
@@ -7,6 +7,7 @@
   <h2>Make Export Zipfile ("{{ project.title }}")</h2>
   <form method="post" id="make_export-zipfile-form">
     {% csrf_token %}
+    {{ form.as_p }}
     <button type="submit" id="submit-button">Make zipfile</button>
   </form>
   </div>

--- a/docs/batch_json_export_conversion.md
+++ b/docs/batch_json_export_conversion.md
@@ -1,0 +1,59 @@
+# Batch-convert legacy C-LARA export bundles to JSON-format bundles
+
+Use the Django management command `convert_exported_project_bundles_to_json` when you already have a folder downloaded from a C-LARA server where each immediate subfolder is one project and contains exactly:
+
+1. one legacy C-LARA export zip, and
+2. one JSON metadata file.
+
+The command imports each legacy zip into the local C-LARA instance, immediately exports it again using the JSON-based export format (`annotated_text.json`), and writes a matching output folder. The metadata JSON file is copied unchanged.
+
+## Basic invocation
+
+From the repository root, with your normal C-LARA environment activated:
+
+```bash
+python manage.py convert_exported_project_bundles_to_json /path/to/legacy_exports /path/to/json_exports --username YOUR_DJANGO_USERNAME
+```
+
+For example:
+
+```bash
+python manage.py convert_exported_project_bundles_to_json \
+  /mnt/adelaide_download/all_legacy_project_exports \
+  /mnt/adelaide_download/all_json_project_exports \
+  --username admin
+```
+
+After a successful run, each output subfolder will have the same name as the input subfolder and will contain:
+
+- a JSON-format zip with the same filename as the input zip; and
+- a copy of the input metadata JSON file.
+
+The command also writes `conversion_index.json` in the destination root summarising converted, skipped, and failed project folders.
+
+## Useful options
+
+```bash
+python manage.py convert_exported_project_bundles_to_json SOURCE_ROOT DEST_ROOT --dry-run
+```
+
+Lists the project folders that would be converted without importing or writing bundles.
+
+```bash
+python manage.py convert_exported_project_bundles_to_json SOURCE_ROOT DEST_ROOT --existing overwrite --username admin
+```
+
+Replaces an existing output subfolder. The default is `--existing skip`; `--existing error` stops on pre-existing output.
+
+```bash
+python manage.py convert_exported_project_bundles_to_json SOURCE_ROOT DEST_ROOT --keep-imported-projects --username admin
+```
+
+Keeps the temporary imported `CLARAProject` database rows after conversion. By default, the command deletes those rows after each JSON-format export has been written, so the conversion database does not fill up with temporary projects.
+
+## Notes
+
+- Run the command in a local C-LARA environment that can already import and export individual project bundles.
+- `SOURCE_ROOT` and `DEST_ROOT` must be different directories.
+- Each input project subfolder must contain exactly one `.zip` and exactly one `.json` file.
+- If `--username` is omitted, the command uses the first superuser, then the first staff user, then the first user in the database.


### PR DESCRIPTION
### Motivation

- Provide a new JSON-format export option that emits an `annotated_text.json` representation of a project bundle suitable for C-LARA-2 workflows.
- Make internal object JSON serialization robust to nested non-primitive values so annotated exports produce stable JSON.
- Add a batch conversion management command to convert legacy export bundles into the new JSON-format bundles.

### Description

- Added a JSON-safety helper `_json_safe_value` and `to_json` methods on `ContentElement` and `Segment`, and used `_json_safe_value` when serializing `Page` and `Text` to ensure annotations and nested objects are serializable (`clara_app/clara_classes.py`).
- Extended export internals to support an `export_format` parameter and a `json` export mode which writes `annotated_text.json` using `clara_project_internal.get_internalised_and_annotated_text`, normalizes audio file paths into the archive layout, and writes the annotated JSON as UTF-8 text (`clara_app/clara_export_import.py`).
- Added helper functions to normalize audio paths (`is_audio_file_path`, `audio_zipfile_path_for_audio_file`) and safer tmp cleanup checks.
- Hooked the new export format into the UI by adding an `export_format` choice to `MakeExportZipForm`, rendering the form in the export template, and threading the `export_format` argument through the async task (`clara_app/forms.py`, `clara_app/export_zipfile_views.py`, `clara_app/templates/clara_app/make_export_zipfile.html`).
- Added a new Django management command `convert_exported_project_bundles_to_json` to batch-convert folders of legacy bundles into JSON-format bundles by importing each legacy zip into a temporary project and immediately exporting it as JSON (`clara_app/management/commands/convert_exported_project_bundles_to_json.py`).
- Added documentation for the batch conversion workflow (`docs/batch_json_export_conversion.md`).

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0c5feb308326a3fca401925b4715)